### PR TITLE
Document vacuum-then-mop MIoT mapping for L10S Pro Ultra Heat

### DIFF
--- a/backend/lib/robots/dreame/DreameL10SProUltraHeatValetudoRobot.js
+++ b/backend/lib/robots/dreame/DreameL10SProUltraHeatValetudoRobot.js
@@ -25,10 +25,12 @@ class DreameL10SProUltraHeatValetudoRobot extends DreameGen4ValetudoRobot {
             Object.assign(
                 {},
                 {
+                    // MIoT preset 3 still triggers the vacuum-then-mop sequence on this model.
                     operationModes: Object.freeze({
                         [stateAttrs.PresetSelectionStateAttribute.MODE.VACUUM_AND_MOP]: 0,
                         [stateAttrs.PresetSelectionStateAttribute.MODE.MOP]: 1,
                         [stateAttrs.PresetSelectionStateAttribute.MODE.VACUUM]: 2,
+                        [stateAttrs.PresetSelectionStateAttribute.MODE.VACUUM_THEN_MOP]: 3,
                     }),
                     highResolutionWaterGrades: true
                 },


### PR DESCRIPTION
## Summary
1. Restore the Dreame L10S Pro Ultra Heat operation-mode map so `VACUUM_THEN_MOP` points to MIoT value 3 and reappears in Valetudo’s preset selector.
2. Note that packaged deployments should rebuild the frontend/backend bundle so the updated mapping ships in release artifacts.
3. Remind operators to redeploy or restart Valetudo after pulling the change so the new class definition loads.
4. Encourage verifying on the robot that “Vacuum then mop” both appears in the UI and runs without firmware errors.

## Testing
- npm run build *(fails: Cannot find module 'ajv/dist/compile/codegen' when running the frontend build)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a090a1348322a5905d3be399a76e